### PR TITLE
Change menu "Announcements" link and title

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ $('#sapling-time').countdown(nextYear.toDate(), function(event) {
                 <a class="nav-link js-scroll-trigger active" href="#getverus">Get Verus</a>
               </li>
               <li class="list-inline-item list-menu-item">
-                <a class="nav-link js-scroll-trigger active" href="https://medium.com/@veruscoin">Announcements</a>
+                <a class="nav-link js-scroll-trigger active" href="https://medium.com/VerusCoin">Blog</a>
               </li>
               <li class="list-inline-item list-menu-item">
                 <a href="#" data-toggle="modal" data-target="#wpModal">White Paper</a>


### PR DESCRIPTION
Change menu "Announcements" to direct to VerusCoin publication on Medium and change title to "Blog"